### PR TITLE
Add Skill, Agent entities with inheritance and shareable matrix URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,7 +192,7 @@ export default function App() {
           }
         />
         <Route
-          path="/matrix"
+          path="/matrix/:types?"
           element={
             <EntityMatrixPage
               onSelectClaim={handleMatrixSelect}

--- a/src/components/claim-matrix.tsx
+++ b/src/components/claim-matrix.tsx
@@ -14,6 +14,7 @@ import {
   type EntityMapping,
 } from '../data/semantic-rankings';
 import { ATOM_TYPES, ATOM_CATEGORIES, type AtomCategory } from '../data/atom-types';
+import { getParentTypeId } from '../data/hierarchy';
 
 interface ClaimMatrixProps {
   /** Single subject type filter (home page use case) */
@@ -48,20 +49,45 @@ export function ClaimMatrix({ subjectTypeId, filterTypeIds, onSelectClaim, searc
     });
   }, [subjectTypeId, filterTypeIds, searchQuery]);
 
-  const groupedMappings = useMemo(() => {
-    const groups: { label: string; mappings: EntityMapping[] }[] = [];
-    let currentGroup = '';
+  // Determine which single type to compute inheritance for
+  const inheritanceTypeId = subjectTypeId ?? (filterTypeIds?.size === 1 ? [...filterTypeIds][0] : null);
 
-    for (const mapping of allMappings) {
-      if (mapping.group !== currentGroup) {
-        currentGroup = mapping.group;
-        groups.push({ label: currentGroup, mappings: [] });
+  // Inherited mappings from parent type(s)
+  const inheritedSections = useMemo(() => {
+    if (!inheritanceTypeId) return [];
+
+    const sections: { parentId: string; parentLabel: string; groups: { label: string; mappings: EntityMapping[] }[] }[] = [];
+    // Build a set of own mapping keys to exclude duplicates
+    const ownKeys = new Set(allMappings.map((m) => `${m.subjectType}:${m.objectType}`));
+
+    let currentType = inheritanceTypeId;
+    while (true) {
+      const parentId = getParentTypeId(currentType);
+      if (!parentId) break;
+
+      const parentAtom = ATOM_TYPES.find((t) => t.id === parentId);
+      if (!parentAtom) break;
+
+      const parentMappings = getEntityMappingsForSubject(parentId).filter(
+        (m) => !ownKeys.has(`${inheritanceTypeId}:${m.objectType}`)
+      );
+
+      if (parentMappings.length > 0) {
+        const groups = groupMappings(parentMappings);
+        sections.push({ parentId, parentLabel: parentAtom.label, groups });
+        // Add these to ownKeys so grandparent doesn't duplicate
+        for (const m of parentMappings) {
+          ownKeys.add(`${inheritanceTypeId}:${m.objectType}`);
+        }
       }
-      groups[groups.length - 1].mappings.push(mapping);
+
+      currentType = parentId;
     }
 
-    return groups;
-  }, [allMappings]);
+    return sections;
+  }, [inheritanceTypeId, allMappings]);
+
+  const groupedMappings = useMemo(() => groupMappings(allMappings), [allMappings]);
 
   const handleRowClick = useCallback(
     (mapping: EntityMapping) => {
@@ -152,6 +178,69 @@ export function ClaimMatrix({ subjectTypeId, filterTypeIds, onSelectClaim, searc
         ))}
       </div>
 
+      {/* Inherited combinations from parent types */}
+      {inheritedSections.map((section) => (
+        <div key={section.parentId} className="mt-6">
+          <div className="flex items-center gap-2 mb-4 pt-4 border-t border-[var(--color-border)]">
+            <h3 className="text-sm font-semibold text-[var(--color-text-muted)]">
+              Inherited from <span className="text-[var(--color-accent)]">{section.parentLabel}</span>
+            </h3>
+            <span className="text-[10px] text-[var(--color-text-muted)] bg-[var(--color-surface-hover)] px-1.5 py-0.5 rounded-full">
+              {section.groups.reduce((sum, g) => sum + g.mappings.length, 0)} combinations
+            </span>
+          </div>
+          <div className="space-y-1 opacity-80" role="list" aria-label={`Combinations inherited from ${section.parentLabel}`}>
+            {section.groups.map((group) => (
+              <div key={group.label} role="group" aria-label={group.label}>
+                <div className="pt-3 pb-1.5">
+                  <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--color-accent)]/40">
+                    {group.label}
+                  </span>
+                </div>
+                <div className="space-y-1.5">
+                  {group.mappings.map((mapping) => {
+                    const rowKey = `inherited-${section.parentId}:${mapping.subjectType}:${mapping.objectType}`;
+                    const hasMultiple = mapping.predicates.length > 1;
+
+                    if (hasMultiple) {
+                      return (
+                        <Dialog key={rowKey}>
+                          <DialogTrigger render={<div role="listitem" />}>
+                            <EntityRow
+                              mapping={mapping}
+                              definedTermColor={definedTermColor}
+                              inheritedSubjectTypeId={inheritanceTypeId ?? undefined}
+                            />
+                          </DialogTrigger>
+                          <DialogContent showCloseButton>
+                            <PredicateDialogBody
+                              mapping={mapping}
+                              definedTermColor={definedTermColor}
+                              onSelect={(predId) => handlePredicateClick(mapping, predId)}
+                            />
+                          </DialogContent>
+                        </Dialog>
+                      );
+                    }
+
+                    return (
+                      <div key={rowKey} role="listitem">
+                        <EntityRow
+                          mapping={mapping}
+                          definedTermColor={definedTermColor}
+                          onClick={() => handleRowClick(mapping)}
+                          inheritedSubjectTypeId={inheritanceTypeId ?? undefined}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
     </div>
   );
 }
@@ -162,12 +251,16 @@ function EntityRow({
   mapping,
   definedTermColor,
   onClick,
+  inheritedSubjectTypeId,
 }: {
   mapping: EntityMapping;
   definedTermColor: string;
   onClick?: () => void;
+  /** When set, displays this type as the subject instead of the mapping's subjectType */
+  inheritedSubjectTypeId?: string;
 }) {
-  const subjectAtom = ATOM_TYPES.find((t) => t.id === mapping.subjectType);
+  const displaySubjectId = inheritedSubjectTypeId ?? mapping.subjectType;
+  const subjectAtom = ATOM_TYPES.find((t) => t.id === displaySubjectId);
   const objectAtom = ATOM_TYPES.find((t) => t.id === mapping.objectType);
   if (!subjectAtom || !objectAtom) return null;
 
@@ -322,6 +415,21 @@ function PredicateCountPill({
 }
 
 // ─── Helpers ─────────────────────────────────────────────────
+
+function groupMappings(mappings: EntityMapping[]): { label: string; mappings: EntityMapping[] }[] {
+  const groups: { label: string; mappings: EntityMapping[] }[] = [];
+  let currentGroup = '';
+
+  for (const mapping of mappings) {
+    if (mapping.group !== currentGroup) {
+      currentGroup = mapping.group;
+      groups.push({ label: currentGroup, mappings: [] });
+    }
+    groups[groups.length - 1].mappings.push(mapping);
+  }
+
+  return groups;
+}
 
 function getDefinedTermColor(): string {
   const dt = ATOM_TYPES.find((t) => t.id === 'DefinedTerm');

--- a/src/data/atom-types.ts
+++ b/src/data/atom-types.ts
@@ -9,7 +9,8 @@ export type AtomCategory =
   | 'generic'
   | 'commerce'
   | 'social'
-  | 'web';
+  | 'web'
+  | 'skill';
 
 export interface SchemaField {
   name: string;
@@ -47,6 +48,7 @@ export const ATOM_CATEGORIES: Record<AtomCategory, { label: string; color: strin
   commerce: { label: 'Commerce', color: '#14b8a6' },
   social: { label: 'Social', color: '#e879f9' },
   web: { label: 'Web', color: '#38bdf8' },
+  skill: { label: 'Skill', color: '#f472b6' },
 };
 
 /**
@@ -516,6 +518,25 @@ export const ATOM_TYPES: AtomType[] = [
     ],
   },
   {
+    id: 'Agent',
+    label: 'Agent',
+    schemaOrgType: 'SoftwareApplication',
+    pluginId: 'agent',
+    category: 'software',
+    description: 'An AI agent — an autonomous software entity that performs tasks, uses tools, and makes decisions.',
+    onchainFields: [
+      { name: 'name', type: 'string', required: true, description: 'Agent name' },
+      { name: 'description', type: 'string', required: true, description: 'What the agent does' },
+    ],
+    enrichmentFields: [
+      { name: 'model', type: 'string', required: false, description: 'Underlying AI model (e.g. Claude, GPT-4)' },
+      { name: 'provider', type: 'string', required: false, description: 'Organization that built the agent' },
+      { name: 'tools', type: 'string[]', required: false, description: 'Tools or APIs the agent can use' },
+      { name: 'capabilities', type: 'string[]', required: false, description: 'High-level capabilities' },
+      { name: 'url', type: 'string', required: false, description: 'Canonical agent URL' },
+    ],
+  },
+  {
     id: 'Dataset',
     label: 'Dataset',
     schemaOrgType: 'Dataset',
@@ -674,6 +695,78 @@ export const ATOM_TYPES: AtomType[] = [
     enrichmentFields: [
       { name: 'totalSupply', type: 'string', required: false, description: 'Total supply' },
       { name: 'logo', type: 'string', required: false, description: 'Token logo URL' },
+    ],
+  },
+
+  // ─── Skill ────────────────────────────────────────────────
+  {
+    id: 'HumanSkill',
+    label: 'Human Skill',
+    schemaOrgType: 'DefinedTerm',
+    pluginId: 'skill',
+    category: 'skill',
+    description: 'A capability or competency performed by a human — programming, design, leadership, etc.',
+    onchainFields: [
+      { name: 'name', type: 'string', required: true, description: 'Skill name' },
+      { name: 'description', type: 'string', required: true, description: 'What this skill enables' },
+    ],
+    enrichmentFields: [
+      { name: 'domain', type: 'string', required: false, description: 'Domain or field (e.g. engineering, design, finance)' },
+      { name: 'proficiencyLevel', type: 'string', required: false, description: 'Typical proficiency scale (beginner, intermediate, expert)' },
+      { name: 'related', type: 'string[]', required: false, description: 'Related skills' },
+      { name: 'certifications', type: 'string[]', required: false, description: 'Relevant certifications' },
+    ],
+  },
+  {
+    id: 'SoftSkill',
+    label: 'Soft Skill',
+    schemaOrgType: 'DefinedTerm',
+    pluginId: 'skill',
+    category: 'skill',
+    description: 'An interpersonal or non-technical skill — communication, leadership, teamwork, etc.',
+    onchainFields: [
+      { name: 'name', type: 'string', required: true, description: 'Skill name' },
+      { name: 'description', type: 'string', required: true, description: 'What this skill enables' },
+    ],
+    enrichmentFields: [
+      { name: 'domain', type: 'string', required: false, description: 'Domain or context' },
+      { name: 'related', type: 'string[]', required: false, description: 'Related skills' },
+    ],
+  },
+  {
+    id: 'HardSkill',
+    label: 'Hard Skill',
+    schemaOrgType: 'DefinedTerm',
+    pluginId: 'skill',
+    category: 'skill',
+    description: 'A technical or measurable skill — Solidity, data analysis, system design, etc.',
+    onchainFields: [
+      { name: 'name', type: 'string', required: true, description: 'Skill name' },
+      { name: 'description', type: 'string', required: true, description: 'What this skill enables' },
+    ],
+    enrichmentFields: [
+      { name: 'domain', type: 'string', required: false, description: 'Domain or field' },
+      { name: 'proficiencyLevel', type: 'string', required: false, description: 'Typical proficiency scale (beginner, intermediate, expert)' },
+      { name: 'related', type: 'string[]', required: false, description: 'Related skills' },
+      { name: 'certifications', type: 'string[]', required: false, description: 'Relevant certifications' },
+    ],
+  },
+  {
+    id: 'AgentSkill',
+    label: 'Agent Skill',
+    schemaOrgType: 'SoftwareApplication',
+    pluginId: 'agent-skill',
+    category: 'software',
+    description: 'A skill performed by an AI agent — code generation, data analysis, tool use, etc.',
+    onchainFields: [
+      { name: 'name', type: 'string', required: true, description: 'Skill name' },
+      { name: 'description', type: 'string', required: true, description: 'What this skill enables' },
+    ],
+    enrichmentFields: [
+      { name: 'domain', type: 'string', required: false, description: 'Domain or field' },
+      { name: 'model', type: 'string', required: false, description: 'AI model or system that provides the skill' },
+      { name: 'tooling', type: 'string[]', required: false, description: 'Tools or APIs the agent uses' },
+      { name: 'related', type: 'string[]', required: false, description: 'Related skills' },
     ],
   },
 

--- a/src/data/example-claims.ts
+++ b/src/data/example-claims.ts
@@ -64,6 +64,25 @@ export const EXAMPLE_CLAIMS: Record<string, ExampleClaim[]> = {
   Service: [
     { subject: 'Alchemy API', subjectType: 'Service', predicateId: 'soldBy', predicateLabel: 'soldBy', object: 'Alchemy', objectType: 'Organization' },
   ],
+  HumanSkill: [
+    { subject: 'Smart Contract Development', subjectType: 'HumanSkill', predicateId: 'relatedTo', predicateLabel: 'relatedTo', object: 'Solidity', objectType: 'DefinedTerm' },
+  ],
+  SoftSkill: [
+    { subject: 'Leadership', subjectType: 'SoftSkill', predicateId: 'complementsSkill', predicateLabel: 'complementsSkill', object: 'Communication', objectType: 'SoftSkill' },
+    { subject: 'Teamwork', subjectType: 'SoftSkill', predicateId: 'requiresSkill', predicateLabel: 'requiresSkill', object: 'Communication', objectType: 'SoftSkill' },
+  ],
+  HardSkill: [
+    { subject: 'Solidity Programming', subjectType: 'HardSkill', predicateId: 'requiresSkill', predicateLabel: 'requiresSkill', object: 'JavaScript', objectType: 'HardSkill' },
+    { subject: 'Protocol Design', subjectType: 'HardSkill', predicateId: 'complementsSkill', predicateLabel: 'complementsSkill', object: 'Game Theory', objectType: 'HardSkill' },
+  ],
+  AgentSkill: [
+    { subject: 'Code Generation', subjectType: 'AgentSkill', predicateId: 'enabledBy', predicateLabel: 'enabledBy', object: 'Claude', objectType: 'SoftwareApplication' },
+    { subject: 'Smart Contract Auditing', subjectType: 'AgentSkill', predicateId: 'supersedes', predicateLabel: 'supersedes', object: 'Manual Code Review', objectType: 'HumanSkill' },
+  ],
+  Agent: [
+    { subject: 'Claude Code', subjectType: 'Agent', predicateId: 'createdBy', predicateLabel: 'createdBy', object: 'Anthropic', objectType: 'Organization' },
+    { subject: 'Devin', subjectType: 'Agent', predicateId: 'taggedWith', predicateLabel: 'taggedWith', object: 'Software Engineering', objectType: 'DefinedTerm' },
+  ],
   SoftwareApplication: [
     { subject: 'MetaMask Extension', subjectType: 'SoftwareApplication', predicateId: 'developedBy', predicateLabel: 'developedBy', object: 'ConsenSys', objectType: 'Organization' },
   ],

--- a/src/data/hierarchy.ts
+++ b/src/data/hierarchy.ts
@@ -6,6 +6,44 @@ export interface HierarchyNode {
 }
 
 /**
+ * Returns the parent node ID for a given type, or null if it's a root child.
+ * Walks the hierarchy tree to find the parent.
+ */
+export function getParentTypeId(typeId: string): string | null {
+  function search(node: HierarchyNode): string | null {
+    if (node.children) {
+      for (const child of node.children) {
+        if (child.id === typeId) return node.id;
+        const found = search(child);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+  const parentId = search(ATOM_HIERARCHY);
+  // 'Thing' is the root — don't treat it as a meaningful parent for inheritance
+  // unless the type is a direct child of Thing (those are top-level, no inheritance)
+  if (parentId === 'Thing') return null;
+  return parentId;
+}
+
+/**
+ * Returns the full ancestor chain for a type (excluding Thing).
+ * E.g. for HardSkill → ['HumanSkill']
+ */
+export function getAncestorTypeIds(typeId: string): string[] {
+  const ancestors: string[] = [];
+  let current = typeId;
+  while (true) {
+    const parent = getParentTypeId(current);
+    if (!parent) break;
+    ancestors.push(parent);
+    current = parent;
+  }
+  return ancestors;
+}
+
+/**
  * Atom type hierarchy based on Schema.org inheritance + protocol-specific extensions.
  * All 36 types from the official intuition-data-structures repo.
  * Used for the D3 radial tree visualization.
@@ -83,6 +121,8 @@ export const ATOM_HIERARCHY: HierarchyNode = {
       children: [
         { id: 'SoftwareApplication', label: 'Software App', category: 'software' },
         { id: 'MobileApplication', label: 'Mobile App', category: 'software' },
+        { id: 'Agent', label: 'Agent', category: 'software' },
+        { id: 'AgentSkill', label: 'Agent Skill', category: 'software' },
       ],
     },
     {
@@ -112,6 +152,15 @@ export const ATOM_HIERARCHY: HierarchyNode = {
       id: 'AggregateRating',
       label: 'Aggregate Rating',
       category: 'social',
+    },
+    {
+      id: 'HumanSkill',
+      label: 'Human Skill',
+      category: 'skill',
+      children: [
+        { id: 'SoftSkill', label: 'Soft Skill', category: 'skill' },
+        { id: 'HardSkill', label: 'Hard Skill', category: 'skill' },
+      ],
     },
     {
       id: 'DefinedTerm',

--- a/src/data/predicates.ts
+++ b/src/data/predicates.ts
@@ -7,11 +7,16 @@ export interface PredicateRule {
 }
 
 /** All subject type IDs that represent "software" broadly */
-const SOFTWARE_TYPES = ['SoftwareSourceCode', 'SoftwareApplication', 'MobileApplication'];
+const SOFTWARE_TYPES = ['SoftwareSourceCode', 'SoftwareApplication', 'MobileApplication', 'Agent'];
 /** All creative work type IDs */
 const CREATIVE_WORK_TYPES = ['Article', 'NewsArticle', 'Book', 'Movie', 'TVSeries', 'MusicRecording', 'MusicAlbum', 'PodcastSeries', 'PodcastEpisode'];
 /** All organization-like type IDs */
 const ORG_TYPES = ['Organization', 'LocalBusiness', 'Brand'];
+/** All skill type IDs */
+/** All human skill type IDs */
+const HUMAN_SKILL_TYPES = ['HumanSkill', 'SoftSkill', 'HardSkill'];
+/** All skill type IDs (human + agent) */
+const SKILL_TYPES = [...HUMAN_SKILL_TYPES, 'AgentSkill'];
 
 /**
  * Predicate compatibility matrix.
@@ -20,12 +25,12 @@ const ORG_TYPES = ['Organization', 'LocalBusiness', 'Brand'];
  * @see https://github.com/0xIntuition/intuition-data-structures
  */
 export const PREDICATES: PredicateRule[] = [
-  // ─── Person → Person ──────────────────────────────────────
-  { id: 'trusts', label: 'trusts', description: 'Subject places trust in object', subjectTypes: ['Person'], objectTypes: ['Person'] },
+  // ─── Person → Person / Agent ─────────────────────────────
+  { id: 'trusts', label: 'trusts', description: 'Subject places trust in object', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', 'Agent', ...SKILL_TYPES] },
   { id: 'follows', label: 'follows', description: 'Subject follows or subscribes to object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, 'MusicGroup'] },
   { id: 'knows', label: 'knows', description: 'Subject has a personal connection with object', subjectTypes: ['Person'], objectTypes: ['Person'] },
   { id: 'endorses', label: 'endorses', description: 'Subject endorses or vouches for object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, 'Product', 'Service'] },
-  { id: 'recommends', label: 'recommends', description: 'Subject recommends object to others', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, 'Product', 'Service', 'Event', 'WebSite', 'Thing'] },
+  { id: 'recommends', label: 'recommends', description: 'Subject recommends object to others', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, ...SKILL_TYPES, 'Product', 'Service', 'Event', 'WebSite', 'Thing'] },
 
   // ─── Person → Organization ────────────────────────────────
   { id: 'memberOf', label: 'memberOf', description: 'Subject is a member of organization', subjectTypes: ['Person'], objectTypes: [...ORG_TYPES, 'MusicGroup'] },
@@ -33,13 +38,18 @@ export const PREDICATES: PredicateRule[] = [
   { id: 'worksAt', label: 'worksAt', description: 'Subject is employed by organization', subjectTypes: ['Person'], objectTypes: [...ORG_TYPES] },
   { id: 'contributorTo', label: 'contributorTo', description: 'Subject contributes to project or org', subjectTypes: ['Person'], objectTypes: [...ORG_TYPES, ...SOFTWARE_TYPES, 'Dataset'] },
 
-  // ─── Person → Abstract ────────────────────────────────────
-  { id: 'interestedIn', label: 'interestedIn', description: 'Subject has interest in concept', subjectTypes: ['Person'], objectTypes: ['DefinedTerm', 'Thing'] },
-  { id: 'expertIn', label: 'expertIn', description: 'Subject has deep expertise in area', subjectTypes: ['Person'], objectTypes: ['DefinedTerm', 'Thing'] },
+  // ─── Person → Abstract / Skill ──────────────────────────────
+  { id: 'interestedIn', label: 'interestedIn', description: 'Subject has interest in concept', subjectTypes: ['Person'], objectTypes: ['DefinedTerm', 'Thing', ...SKILL_TYPES] },
+  { id: 'expertIn', label: 'expertIn', description: 'Subject has deep expertise in area', subjectTypes: ['Person'], objectTypes: ['DefinedTerm', 'Thing', ...SKILL_TYPES] },
+  { id: 'hasSkill', label: 'hasSkill', description: 'Person possesses this skill', subjectTypes: ['Person'], objectTypes: [...SKILL_TYPES] },
+  { id: 'learningSkill', label: 'learningSkill', description: 'Person is currently learning this skill', subjectTypes: ['Person'], objectTypes: [...SKILL_TYPES] },
   { id: 'advocates', label: 'advocates', description: 'Subject publicly supports concept', subjectTypes: ['Person', ...ORG_TYPES], objectTypes: ['DefinedTerm', 'Thing'] },
 
+  // ─── Person → Skill ─────────────────────────────────────
+  { id: 'audited', label: 'audited', description: 'Person has audited or reviewed the skill', subjectTypes: ['Person'], objectTypes: [...SKILL_TYPES] },
+
   // ─── Person → Software/Thing ──────────────────────────────
-  { id: 'uses', label: 'uses', description: 'Subject uses the software or tool', subjectTypes: ['Person', ...ORG_TYPES], objectTypes: [...SOFTWARE_TYPES, 'Product', 'Service', 'Thing'] },
+  { id: 'uses', label: 'uses', description: 'Subject uses the software, tool, or skill', subjectTypes: ['Person', ...ORG_TYPES, 'Agent'], objectTypes: [...SOFTWARE_TYPES, ...SKILL_TYPES, 'Product', 'Service', 'Thing'] },
   { id: 'created', label: 'created', description: 'Subject created the object', subjectTypes: ['Person'], objectTypes: [...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, 'ImageObject', 'VideoObject', 'Dataset', 'WebSite', 'Product', 'Thing'] },
   { id: 'likes', label: 'likes', description: 'Subject likes or favors object', subjectTypes: ['Person'], objectTypes: ['Thing', ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, 'MusicGroup', 'ImageObject', 'VideoObject', 'Product', 'Place', 'Event', 'WebSite', 'DefinedTerm'] },
   { id: 'reviewed', label: 'reviewed', description: 'Subject has reviewed object', subjectTypes: ['Person'], objectTypes: ['Thing', ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, 'Product', 'Service', 'Event'] },
@@ -66,8 +76,8 @@ export const PREDICATES: PredicateRule[] = [
   { id: 'maintains', label: 'maintains', description: 'Organization maintains software', subjectTypes: [...ORG_TYPES], objectTypes: [...SOFTWARE_TYPES] },
   { id: 'headquarteredIn', label: 'headquarteredIn', description: 'Organization HQ is in place', subjectTypes: [...ORG_TYPES], objectTypes: ['Place'] },
 
-  // ─── Organization → Abstract ──────────────────────────────
-  { id: 'supports', label: 'supports', description: 'Organization supports concept or initiative', subjectTypes: [...ORG_TYPES], objectTypes: ['DefinedTerm', ...ORG_TYPES, 'Person', 'Thing'] },
+  // ─── Organization / Person → Abstract ────────────────────
+  { id: 'supports', label: 'supports', description: 'Subject supports concept, initiative, or agent', subjectTypes: ['Person', ...ORG_TYPES], objectTypes: ['DefinedTerm', ...ORG_TYPES, 'Person', 'Agent', 'Thing'] },
 
   // ─── Organization → Commerce ──────────────────────────────
   { id: 'offers', label: 'offers', description: 'Organization offers product or service', subjectTypes: [...ORG_TYPES], objectTypes: ['Product', 'Service'] },
@@ -81,7 +91,7 @@ export const PREDICATES: PredicateRule[] = [
   { id: 'implements', label: 'implements', description: 'Software implements concept or standard', subjectTypes: [...SOFTWARE_TYPES], objectTypes: ['DefinedTerm'] },
   { id: 'dependsOn', label: 'dependsOn', description: 'Software depends on another', subjectTypes: [...SOFTWARE_TYPES], objectTypes: [...SOFTWARE_TYPES] },
   { id: 'alternativeTo', label: 'alternativeTo', description: 'Software is alternative to another', subjectTypes: [...SOFTWARE_TYPES], objectTypes: [...SOFTWARE_TYPES] },
-  { id: 'forkOf', label: 'forkOf', description: 'Software is a fork of another', subjectTypes: ['SoftwareSourceCode'], objectTypes: ['SoftwareSourceCode'] },
+  { id: 'forkOf', label: 'forkOf', description: 'Software or skill is a fork of another', subjectTypes: ['SoftwareSourceCode', ...SKILL_TYPES], objectTypes: ['SoftwareSourceCode', ...SKILL_TYPES] },
 
   // ─── Blockchain → * ───────────────────────────────────────
   { id: 'ownedBy', label: 'ownedBy', description: 'Account or contract is owned by entity', subjectTypes: ['EthereumAccount', 'EthereumSmartContract', 'EthereumERC20'], objectTypes: ['Person', ...ORG_TYPES] },
@@ -109,6 +119,19 @@ export const PREDICATES: PredicateRule[] = [
   { id: 'relatedTo', label: 'relatedTo', description: 'Entity is related to another', subjectTypes: ['DefinedTerm', 'Thing'], objectTypes: ['DefinedTerm', 'Thing'] },
   { id: 'subConceptOf', label: 'subConceptOf', description: 'Term is a sub-concept of another', subjectTypes: ['DefinedTerm'], objectTypes: ['DefinedTerm'] },
   { id: 'oppositeOf', label: 'oppositeOf', description: 'Term is opposite to another', subjectTypes: ['DefinedTerm'], objectTypes: ['DefinedTerm'] },
+
+  // ─── Skill → * ───────────────────────────────────────────
+  { id: 'requiresSkill', label: 'requiresSkill', description: 'Skill requires another skill as prerequisite', subjectTypes: [...SKILL_TYPES], objectTypes: [...SKILL_TYPES] },
+  { id: 'complementsSkill', label: 'complementsSkill', description: 'Skill complements or pairs well with another', subjectTypes: [...SKILL_TYPES], objectTypes: [...SKILL_TYPES] },
+  { id: 'supersedes', label: 'supersedes', description: 'Skill supersedes or replaces another', subjectTypes: [...SKILL_TYPES], objectTypes: [...SKILL_TYPES] },
+  { id: 'inspiredBy', label: 'inspiredBy', description: 'Skill is inspired by another skill', subjectTypes: [...SKILL_TYPES], objectTypes: [...SKILL_TYPES] },
+  { id: 'leverages', label: 'leverages', description: 'Skill leverages or builds on another skill', subjectTypes: [...SKILL_TYPES], objectTypes: [...SKILL_TYPES] },
+  { id: 'enabledBy', label: 'enabledBy', description: 'Skill is enabled by a tool or software', subjectTypes: ['AgentSkill'], objectTypes: [...SOFTWARE_TYPES, 'Thing'] },
+  { id: 'performedBy', label: 'performedBy', description: 'Skill is performed by an agent or person', subjectTypes: [...SKILL_TYPES], objectTypes: ['Person', ...ORG_TYPES, 'Agent', 'Thing'] },
+
+  // ─── Agent → Skill ──────────────────────────────────────
+  { id: 'hasAgentSkill', label: 'hasSkill', description: 'Agent possesses or provides this skill', subjectTypes: ['Agent'], objectTypes: [...SKILL_TYPES] },
+  { id: 'capableOf', label: 'capableOf', description: 'Agent is capable of performing this skill', subjectTypes: ['Agent'], objectTypes: [...SKILL_TYPES] },
 
   // ─── Generic ──────────────────────────────────────────────
   { id: 'isA', label: 'isA', description: 'Entity is an instance of type/concept', subjectTypes: ['Thing', 'Person', ...ORG_TYPES, ...SOFTWARE_TYPES, 'Product', 'Service'], objectTypes: ['DefinedTerm', 'Thing'] },

--- a/src/data/semantic-rankings.ts
+++ b/src/data/semantic-rankings.ts
@@ -104,6 +104,20 @@ const PREDICATE_SEMANTICS: Record<string, { group: SemanticGroup; priority: numb
   taggedWith:      { group: 'Content & Media', priority: 1 },
   partOf:          { group: 'Content & Media', priority: 2 },
 
+  hasSkill:        { group: 'Interests & Expertise', priority: 4 },
+  learningSkill:   { group: 'Interests & Expertise', priority: 5 },
+  audited:         { group: 'Interests & Expertise', priority: 6 },
+  hasAgentSkill:   { group: 'Interests & Expertise', priority: 7 },
+  capableOf:       { group: 'Interests & Expertise', priority: 8 },
+
+  requiresSkill:   { group: 'Taxonomy & Classification', priority: 5 },
+  complementsSkill:{ group: 'Taxonomy & Classification', priority: 6 },
+  supersedes:      { group: 'Taxonomy & Classification', priority: 7 },
+  inspiredBy:      { group: 'Taxonomy & Classification', priority: 8 },
+  leverages:       { group: 'Taxonomy & Classification', priority: 9 },
+  enabledBy:       { group: 'Software & Tools', priority: 6 },
+  performedBy:     { group: 'Membership & Work', priority: 8 },
+
   isA:             { group: 'Taxonomy & Classification', priority: 1 },
   relatedTo:       { group: 'Taxonomy & Classification', priority: 2 },
   subConceptOf:    { group: 'Taxonomy & Classification', priority: 3 },

--- a/src/pages/entity-matrix.tsx
+++ b/src/pages/entity-matrix.tsx
@@ -1,16 +1,43 @@
-import { useState, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { ClaimMatrix } from '../components/claim-matrix';
 import { EntityTypeTagCloud } from '../components/entity-type-tag-cloud';
+import { ATOM_TYPES } from '../data/atom-types';
 
 interface EntityMatrixPageProps {
   onSelectClaim: (subjectTypeId: string, predicateId: string, objectTypeId: string) => void;
 }
 
+/** Valid atom type IDs for URL validation */
+const VALID_TYPE_IDS = new Set(ATOM_TYPES.map((t) => t.id));
+
+function parseTypesFromParam(param: string | undefined): Set<string> {
+  if (!param) return new Set();
+  const ids = param.split(',').filter((id) => VALID_TYPE_IDS.has(id));
+  return new Set(ids);
+}
+
+function typesToParam(types: Set<string>): string {
+  return [...types].sort().join(',');
+}
+
 export function EntityMatrixPage({ onSelectClaim }: EntityMatrixPageProps) {
   const navigate = useNavigate();
-  const [selectedTypeIds, setSelectedTypeIds] = useState<Set<string>>(new Set());
+  const { types: typesParam } = useParams<{ types: string }>();
+
+  const selectedTypeIds = useMemo(() => parseTypesFromParam(typesParam), [typesParam]);
+
+  const updateUrl = useCallback(
+    (next: Set<string>) => {
+      if (next.size === 0) {
+        navigate('/matrix', { replace: true });
+      } else {
+        navigate(`/matrix/${typesToParam(next)}`, { replace: true });
+      }
+    },
+    [navigate]
+  );
 
   const handleSelectClaim = useCallback(
     (subjectTypeId: string, predicateId: string, objectTypeId: string) => {
@@ -20,24 +47,22 @@ export function EntityMatrixPage({ onSelectClaim }: EntityMatrixPageProps) {
     [onSelectClaim, navigate]
   );
 
-  const handleToggleType = useCallback((typeId: string) => {
-    setSelectedTypeIds((prev) => {
-      const next = new Set(prev);
+  const handleToggleType = useCallback(
+    (typeId: string) => {
+      const next = new Set(selectedTypeIds);
       if (next.has(typeId)) {
         next.delete(typeId);
       } else {
         next.add(typeId);
       }
-      return next;
-    });
-  }, []);
+      updateUrl(next);
+    },
+    [selectedTypeIds, updateUrl]
+  );
 
   const handleClearAll = useCallback(() => {
-    setSelectedTypeIds(new Set());
-  }, []);
-
-  // Stable reference for the set passed to ClaimMatrix
-  const filterTypeIds = useMemo(() => selectedTypeIds, [selectedTypeIds]);
+    updateUrl(new Set());
+  }, [updateUrl]);
 
   return (
     <main className="px-4 sm:px-6 py-8 space-y-6" data-tutorial-step="entity-matrix">
@@ -50,7 +75,7 @@ export function EntityMatrixPage({ onSelectClaim }: EntityMatrixPageProps) {
 
       {/* Matrix */}
       <ClaimMatrix
-        filterTypeIds={filterTypeIds}
+        filterTypeIds={selectedTypeIds}
         onSelectClaim={handleSelectClaim}
       />
     </main>


### PR DESCRIPTION
## Summary
- **New entity types**: HumanSkill (with SoftSkill, HardSkill children), AgentSkill (under Software), and Agent (under Software)
- **New predicates**: `audited`, `inspiredBy`, `leverages`, `hasAgentSkill`, `capableOf` + extended existing predicates (`trusts`, `uses`, `recommends`, `supports`, `forkOf`) to cover Person→Skill, Skill→Skill, Agent→Skill, Person→Agent, and Agent→Agent relations
- **Inherited combinations**: When a sub-entity is selected in the matrix, combinations inherited from parent entities are shown in a distinct "Inherited from {Parent}" section
- **Shareable matrix URLs**: Selected entity types are reflected in the URL path (`/matrix/Agent,HumanSkill`), enabling shareable filtered views

## Test plan
- [ ] Verify new entity types appear in tag cloud, hierarchy tree, and matrix
- [ ] Select a sub-entity (e.g. SoftSkill) and confirm inherited combinations from HumanSkill are shown
- [ ] Toggle entities on the matrix page and verify the URL updates
- [ ] Copy a matrix URL with selected types, open in new tab, confirm selection is restored
- [ ] Verify predicates filter correctly for new entity types in the claim builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)