### PR TITLE
feat: Add Agent→Agent predicates and opposes for AgentScore use cases

### DIFF
--- a/src/data/predicates.ts
+++ b/src/data/predicates.ts
@@ -27,6 +27,7 @@ const SKILL_TYPES = [...HUMAN_SKILL_TYPES, 'AgentSkill'];
 export const PREDICATES: PredicateRule[] = [
   // ─── Person → Person / Agent ─────────────────────────────
   { id: 'trusts', label: 'trusts', description: 'Subject places trust in object', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', 'Agent', ...SKILL_TYPES] },
+  { id: 'opposes', label: 'opposes', description: 'Person or agent stakes against another entity', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', 'Agent'] },
   { id: 'follows', label: 'follows', description: 'Subject follows or subscribes to object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, 'MusicGroup'] },
   { id: 'knows', label: 'knows', description: 'Subject has a personal connection with object', subjectTypes: ['Person'], objectTypes: ['Person'] },
   { id: 'endorses', label: 'endorses', description: 'Subject endorses or vouches for object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, 'Product', 'Service'] },

--- a/src/data/predicates.ts
+++ b/src/data/predicates.ts
@@ -30,7 +30,7 @@ export const PREDICATES: PredicateRule[] = [
   { id: 'follows', label: 'follows', description: 'Subject follows or subscribes to object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, 'MusicGroup'] },
   { id: 'knows', label: 'knows', description: 'Subject has a personal connection with object', subjectTypes: ['Person'], objectTypes: ['Person'] },
   { id: 'endorses', label: 'endorses', description: 'Subject endorses or vouches for object', subjectTypes: ['Person'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, 'Product', 'Service'] },
-  { id: 'recommends', label: 'recommends', description: 'Subject recommends object to others', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', ...ORG_TYPES, ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, ...SKILL_TYPES, 'Product', 'Service', 'Event', 'WebSite', 'Thing'] },
+  { id: 'recommends', label: 'recommends', description: 'Subject recommends object to others', subjectTypes: ['Person', 'Agent'], objectTypes: ['Person', 'Agent', ...ORG_TYPES, ...SOFTWARE_TYPES, ...CREATIVE_WORK_TYPES, ...SKILL_TYPES, 'Product', 'Service', 'Event', 'WebSite', 'Thing'] },
 
   // ─── Person → Organization ────────────────────────────────
   { id: 'memberOf', label: 'memberOf', description: 'Subject is a member of organization', subjectTypes: ['Person'], objectTypes: [...ORG_TYPES, 'MusicGroup'] },
@@ -132,6 +132,11 @@ export const PREDICATES: PredicateRule[] = [
   // ─── Agent → Skill ──────────────────────────────────────
   { id: 'hasAgentSkill', label: 'hasSkill', description: 'Agent possesses or provides this skill', subjectTypes: ['Agent'], objectTypes: [...SKILL_TYPES] },
   { id: 'capableOf', label: 'capableOf', description: 'Agent is capable of performing this skill', subjectTypes: ['Agent'], objectTypes: [...SKILL_TYPES] },
+
+  // ─── Agent → Agent ──────────────────────────────────────
+  { id: 'evaluatedBy', label: 'evaluatedBy', description: "Agent or person evaluated another agent's output", subjectTypes: ['Agent'], objectTypes: ['Agent', 'Person'] },
+  { id: 'delegatedTo', label: 'delegatedTo', description: 'Agent or person delegated a task to another agent', subjectTypes: ['Agent', 'Person'], objectTypes: ['Agent'] },
+  { id: 'collaboratedWith', label: 'collaboratedWith', description: 'Two agents worked together on a task', subjectTypes: ['Agent'], objectTypes: ['Agent'] },
 
   // ─── Generic ──────────────────────────────────────────────
   { id: 'isA', label: 'isA', description: 'Entity is an instance of type/concept', subjectTypes: ['Thing', 'Person', ...ORG_TYPES, ...SOFTWARE_TYPES, 'Product', 'Service'], objectTypes: ['DefinedTerm', 'Thing'] },


### PR DESCRIPTION
## Summary

Adding predicates for Agent-to-Agent relationships and opposition 
signals based on AgentScore usage patterns on Intuition Testnet.

### New predicates

- `evaluatedBy` — Agent → Agent/Person
- `delegatedTo` — Agent/Person → Agent
- `collaboratedWith` — Agent → Agent
- `opposes` — Person/Agent → Person/Agent

### Extended predicates

- `recommends` — added Agent to objectTypes

### Already covered (no changes needed)

- `trusts` — Agent→Agent already supported
- `createdBy` — Agent→Person/Org already covered via SOFTWARE_TYPES inheritance

### Context

These predicates come from real usage patterns in 
[AgentScore](https://agentscore-gilt.vercel.app), a trust scoring 
marketplace for AI agents built on Intuition Protocol.

Agent→Agent predicates support Phase 3 Proof of Performance 
where agents evaluate and delegate tasks to each other.
The `opposes` predicate enables counter-signaling in trust markets.

Built on top of #3 by @jeremie-olivier.