### PR TITLE
feat: ecosystem ontology definitions for 11 apps (Mission 04)

### DIFF
--- a/ontologies/README.md
+++ b/ontologies/README.md
@@ -1,0 +1,61 @@
+# Ecosystem Ontology Definitions
+
+This directory contains formal ontology definitions for each app in the [Intuition-Box](https://github.com/intuition-box) ecosystem.
+
+## Structure
+
+Each JSON file defines the **atom types**, **predicates**, and **valid type combinations** for one ecosystem app. All definitions follow the same schema used by the Ontology explorer's `PredicateRule` format.
+
+## Schema
+
+```typescript
+interface AppOntology {
+  app: string;              // App name
+  repo: string;             // GitHub repo path
+  description: string;      // What the app does
+  atomTypes: AtomType[];    // Entity types the app uses
+  predicates: Predicate[];  // Relationships the app defines
+}
+
+interface AtomType {
+  id: string;               // Schema.org-compatible type ID
+  label: string;            // Human-readable label
+  description: string;      // What this type represents
+}
+
+interface Predicate {
+  id: string;               // Predicate ID (camelCase)
+  label: string;            // Display label
+  description: string;      // What this relationship means
+  subjectTypes: string[];   // Valid subject atom types
+  objectTypes: string[];    // Valid object atom types
+}
+```
+
+## Cross-App Consistency
+
+Shared types use identical IDs across all apps:
+
+| Shared ID | Used By |
+|-----------|---------|
+| `Person` | All apps (wallet identity) |
+| `trusts` | Sofia, Extension, Graph, Spread Trust, AgentId |
+| `Organization` | Values, Atlas |
+| `SoftwareApplication` | AgentId, MCP Server |
+
+## Files
+
+| File | App | Atom Types | Predicates |
+|------|-----|:----------:|:----------:|
+| `sofia.json` | Sofia | 7 | 7 |
+| `atlas.json` | Atlas | 5 | 5 |
+| `agentid.json` | AgentId | 5 | 7 |
+| `values.json` | Values | 4 | 4 |
+| `graph.json` | Graph | 3 | 3 |
+| `spread-trust.json` | Spread Trust | 3 | 3 |
+| `fee-proxy.json` | Fee Proxy Template | 3 | 3 |
+| `rpc.json` | RPC | 3 | 2 |
+| `mcp-server.json` | MCP Server | 3 | 3 |
+| `ideation.json` | Intuition Ideation | 3 | 3 |
+| `ontology.json` | Ontology | 3 | 3 |
+| `_shared.json` | Cross-app shared types | 6 | 2 |

--- a/ontologies/_shared.json
+++ b/ontologies/_shared.json
@@ -1,0 +1,15 @@
+{
+  "description": "Cross-app shared types — atom types and predicates that appear across multiple ecosystem apps. All apps MUST use these exact IDs for consistency.",
+  "sharedAtomTypes": [
+    { "id": "Person", "label": "Person / User", "description": "Wallet address. Universal identity across all Intuition apps.", "usedBy": ["Sofia", "Atlas", "AgentId", "Values", "Graph", "Spread Trust", "Fee Proxy", "RPC", "MCP Server", "Ideation", "Ontology"] },
+    { "id": "Organization", "label": "Organization", "description": "DAO, company, or community entity.", "usedBy": ["Atlas", "Values"] },
+    { "id": "DefinedTerm", "label": "Concept / Tag", "description": "Abstract concept, skill, value, or classification term.", "usedBy": ["Sofia", "AgentId", "Values", "Atlas", "Ideation", "Ontology"] },
+    { "id": "SoftwareApplication", "label": "Software / Agent", "description": "Software application or AI agent.", "usedBy": ["AgentId", "MCP Server"] },
+    { "id": "EthereumSmartContract", "label": "Smart Contract", "description": "On-chain smart contract (e.g., Fee Proxy, MultiVault).", "usedBy": ["Fee Proxy"] },
+    { "id": "Event", "label": "Event", "description": "Community event or gathering.", "usedBy": ["Atlas"] }
+  ],
+  "sharedPredicates": [
+    { "id": "trusts", "label": "trusts", "description": "Universal trust relationship between entities.", "usedBy": ["Sofia", "Graph", "Spread Trust", "AgentId"] },
+    { "id": "memberOf", "label": "member of", "description": "Person belongs to an organization or community.", "usedBy": ["Atlas", "Values"] }
+  ]
+}

--- a/ontologies/agentid.json
+++ b/ontologies/agentid.json
@@ -1,0 +1,21 @@
+{
+  "app": "AgentId",
+  "repo": "intuition-box/agentId",
+  "description": "Decentralized Trust Registry for AI Agents. Register identity, declare capabilities, and build verifiable reputation through crypto-economic staking.",
+  "atomTypes": [
+    { "id": "SoftwareApplication", "label": "Agent", "description": "AI agent identity registered on-chain" },
+    { "id": "DefinedTerm", "label": "Capability", "description": "Declared agent capability or skill" },
+    { "id": "Thing", "label": "Reputation", "description": "Staking-based verifiable reputation score" },
+    { "id": "Person", "label": "Operator", "description": "Human operator who controls/owns the agent" },
+    { "id": "Thing", "label": "Credential", "description": "Verifiable agent credential or certification" }
+  ],
+  "predicates": [
+    { "id": "has_capability", "label": "has capability", "description": "Agent declares a specific capability", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["DefinedTerm"] },
+    { "id": "operated_by", "label": "operated by", "description": "Agent is operated/owned by a human", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["Person"] },
+    { "id": "has_reputation", "label": "has reputation", "description": "Agent has an on-chain reputation score", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["Thing"] },
+    { "id": "staked_on", "label": "staked on", "description": "Operator has staked tokens on an agent's identity", "subjectTypes": ["Person"], "objectTypes": ["SoftwareApplication"] },
+    { "id": "endorses", "label": "endorses", "description": "Agent endorses another agent's capabilities", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["SoftwareApplication"] },
+    { "id": "holds_credential", "label": "holds credential", "description": "Agent holds a verifiable credential", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["Thing"] },
+    { "id": "trusts", "label": "trusts", "description": "Operator trusts an agent", "subjectTypes": ["Person"], "objectTypes": ["SoftwareApplication"] }
+  ]
+}

--- a/ontologies/atlas.json
+++ b/ontologies/atlas.json
@@ -1,0 +1,19 @@
+{
+  "app": "Atlas",
+  "repo": "intuition-box/Atlas",
+  "description": "Community organization and engagement platform for teams and DAOs.",
+  "atomTypes": [
+    { "id": "Organization", "label": "Community", "description": "Organized group, DAO, or team" },
+    { "id": "Person", "label": "Member", "description": "Community participant (wallet address)" },
+    { "id": "Thing", "label": "Channel", "description": "Communication or topic channel within a community" },
+    { "id": "Event", "label": "Event", "description": "Community event or gathering" },
+    { "id": "DefinedTerm", "label": "Role", "description": "Member role within the community (admin, mod, etc.)" }
+  ],
+  "predicates": [
+    { "id": "memberOf", "label": "member of", "description": "Person is a member of a community", "subjectTypes": ["Person"], "objectTypes": ["Organization"] },
+    { "id": "has_role", "label": "has role", "description": "Member holds a specific role in the community", "subjectTypes": ["Person"], "objectTypes": ["DefinedTerm"] },
+    { "id": "participates_in", "label": "participates in", "description": "Member participates in a channel", "subjectTypes": ["Person"], "objectTypes": ["Thing"] },
+    { "id": "organizedEvent", "label": "organized", "description": "Member organized a community event", "subjectTypes": ["Person"], "objectTypes": ["Event"] },
+    { "id": "belongs_to", "label": "belongs to", "description": "Channel belongs to a community", "subjectTypes": ["Thing"], "objectTypes": ["Organization"] }
+  ]
+}

--- a/ontologies/fee-proxy.json
+++ b/ontologies/fee-proxy.json
@@ -1,0 +1,15 @@
+{
+  "app": "Fee Proxy Template",
+  "repo": "intuition-box/Fee-Proxy-Template",
+  "description": "Customizable proxy contract for Intuition MultiVault. Developers deploy their own proxy with configurable creation fees, deposit percentages, and admin controls.",
+  "atomTypes": [
+    { "id": "EthereumSmartContract", "label": "FeeProxy", "description": "Deployed fee proxy contract instance" },
+    { "id": "Person", "label": "Admin", "description": "Proxy administrator who controls fee configuration" },
+    { "id": "Thing", "label": "FeeConfig", "description": "Fee configuration parameters (creation fee + deposit percentage)" }
+  ],
+  "predicates": [
+    { "id": "controlledBy", "label": "controlled by", "description": "Fee proxy is administered by a wallet", "subjectTypes": ["EthereumSmartContract"], "objectTypes": ["Person"] },
+    { "id": "has_config", "label": "has config", "description": "Proxy has a specific fee configuration", "subjectTypes": ["EthereumSmartContract"], "objectTypes": ["Thing"] },
+    { "id": "deployedOn", "label": "deployed on", "description": "Proxy contract is deployed on Intuition L3", "subjectTypes": ["EthereumSmartContract"], "objectTypes": ["Thing"] }
+  ]
+}

--- a/ontologies/graph.json
+++ b/ontologies/graph.json
@@ -1,0 +1,15 @@
+{
+  "app": "Graph",
+  "repo": "intuition-box/Graph",
+  "description": "Trust graph visualization tool showing weighted trust connections between users.",
+  "atomTypes": [
+    { "id": "Person", "label": "User", "description": "Wallet address in the trust network" },
+    { "id": "Thing", "label": "TrustEdge", "description": "Weighted trust connection between users" },
+    { "id": "Thing", "label": "Cluster", "description": "Group of mutually trusted users" }
+  ],
+  "predicates": [
+    { "id": "trusts", "label": "trusts", "description": "User places trust in another user", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "trust_weight", "label": "trust weight", "description": "Weighted trust score between users", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "in_cluster", "label": "in cluster", "description": "User belongs to a trust cluster", "subjectTypes": ["Person"], "objectTypes": ["Thing"] }
+  ]
+}

--- a/ontologies/ideation.json
+++ b/ontologies/ideation.json
@@ -1,0 +1,15 @@
+{
+  "app": "Intuition Ideation",
+  "repo": "intuition-box/intuition-ideation-skill",
+  "description": "Claude Code skill for brainstorming, structuring, and publishing product ideas for the Intuition Protocol ecosystem.",
+  "atomTypes": [
+    { "id": "Thing", "label": "Idea", "description": "Product idea or concept for the ecosystem" },
+    { "id": "Person", "label": "Builder", "description": "Idea creator/proposer" },
+    { "id": "DefinedTerm", "label": "Category", "description": "Idea category (DeFi, Social, Infrastructure, etc.)" }
+  ],
+  "predicates": [
+    { "id": "proposed_by", "label": "proposed by", "description": "Idea was proposed by a builder", "subjectTypes": ["Thing"], "objectTypes": ["Person"] },
+    { "id": "taggedWith", "label": "categorized as", "description": "Idea is categorized under a domain", "subjectTypes": ["Thing"], "objectTypes": ["DefinedTerm"] },
+    { "id": "dependsOn", "label": "builds on", "description": "Idea builds on or depends on another idea", "subjectTypes": ["Thing"], "objectTypes": ["Thing"] }
+  ]
+}

--- a/ontologies/mcp-server.json
+++ b/ontologies/mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "app": "MCP Server",
+  "repo": "intuition-box/MCP-Server",
+  "description": "MCP server exposing Intuition protocol knowledge graph data as tools that LLMs can call.",
+  "atomTypes": [
+    { "id": "SoftwareApplication", "label": "MCPServer", "description": "MCP server instance exposing protocol data" },
+    { "id": "Thing", "label": "MCPTool", "description": "Individual tool function exposed by the server" },
+    { "id": "SoftwareApplication", "label": "LLMAgent", "description": "AI agent consuming the MCP server" }
+  ],
+  "predicates": [
+    { "id": "exposes", "label": "exposes", "description": "MCP server exposes a callable tool", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["Thing"] },
+    { "id": "queries", "label": "queries", "description": "LLM agent queries the MCP server", "subjectTypes": ["SoftwareApplication"], "objectTypes": ["SoftwareApplication"] },
+    { "id": "dependsOn", "label": "depends on", "description": "MCP tool reads from on-chain atoms/triples", "subjectTypes": ["Thing"], "objectTypes": ["Thing"] }
+  ]
+}

--- a/ontologies/ontology.json
+++ b/ontologies/ontology.json
@@ -1,0 +1,15 @@
+{
+  "app": "Ontology",
+  "repo": "intuition-box/Ontology",
+  "description": "Ontology explorer and visualizer. The meta-tool for defining, browsing, and publishing atom types, predicates, and valid type combinations.",
+  "atomTypes": [
+    { "id": "DefinedTerm", "label": "EntityType", "description": "Schema type definition (e.g., Person, Organization, Skill)" },
+    { "id": "DefinedTerm", "label": "Predicate", "description": "Relationship type definition" },
+    { "id": "Thing", "label": "Claim", "description": "User-created assertion (subject-predicate-object triple)" }
+  ],
+  "predicates": [
+    { "id": "isA", "label": "is a", "description": "Entity type inherits from another type", "subjectTypes": ["DefinedTerm"], "objectTypes": ["DefinedTerm"] },
+    { "id": "has_predicate", "label": "has predicate", "description": "Entity type supports a specific predicate", "subjectTypes": ["DefinedTerm"], "objectTypes": ["DefinedTerm"] },
+    { "id": "valid_for", "label": "valid for", "description": "Predicate is valid for a specific entity type (domain/range)", "subjectTypes": ["DefinedTerm"], "objectTypes": ["DefinedTerm"] }
+  ]
+}

--- a/ontologies/rpc.json
+++ b/ontologies/rpc.json
@@ -1,0 +1,14 @@
+{
+  "app": "RPC",
+  "repo": "intuition-box/RPC",
+  "description": "One-click deployable RPC endpoint tooling for the Intuition L3 chain.",
+  "atomTypes": [
+    { "id": "WebSite", "label": "RPCEndpoint", "description": "RPC service endpoint instance" },
+    { "id": "Person", "label": "Operator", "description": "Node operator running the RPC endpoint" },
+    { "id": "Thing", "label": "Chain", "description": "Blockchain network (Intuition L3)" }
+  ],
+  "predicates": [
+    { "id": "serves", "label": "serves", "description": "RPC endpoint serves a specific chain", "subjectTypes": ["WebSite"], "objectTypes": ["Thing"] },
+    { "id": "operated_by", "label": "operated by", "description": "RPC endpoint is operated by a node operator", "subjectTypes": ["WebSite"], "objectTypes": ["Person"] }
+  ]
+}

--- a/ontologies/sofia-fee-proxy-dashboard.json
+++ b/ontologies/sofia-fee-proxy-dashboard.json
@@ -1,0 +1,15 @@
+{
+  "app": "Sofia Fee Proxy Dashboard",
+  "repo": "intuition-box/Sofia-Fee-Proxy-Dashboard",
+  "description": "Dashboard showing revenue metrics and analytics for Sofia's fee proxy contract.",
+  "atomTypes": [
+    { "id": "EthereumSmartContract", "label": "FeeProxy", "description": "Sofia's deployed fee proxy contract" },
+    { "id": "Thing", "label": "Metric", "description": "Revenue or volume metric data point" },
+    { "id": "DefinedTerm", "label": "Period", "description": "Time period for metric aggregation (daily/weekly/monthly)" }
+  ],
+  "predicates": [
+    { "id": "generated_revenue", "label": "generated revenue", "description": "Fee proxy generated revenue in a period", "subjectTypes": ["EthereumSmartContract"], "objectTypes": ["Thing"] },
+    { "id": "during_period", "label": "during period", "description": "Metric is aggregated over a time period", "subjectTypes": ["Thing"], "objectTypes": ["DefinedTerm"] },
+    { "id": "proxy_for", "label": "proxy for", "description": "Fee proxy serves a specific application", "subjectTypes": ["EthereumSmartContract"], "objectTypes": ["SoftwareApplication"] }
+  ]
+}

--- a/ontologies/sofia.json
+++ b/ontologies/sofia.json
@@ -1,0 +1,23 @@
+{
+  "app": "Sofia",
+  "repo": "intuition-box/Sofia",
+  "description": "Chrome extension that transforms browsing into certified knowledge on the Intuition protocol. AI workflows classify intent, pin URLs to IPFS, and create atoms/triples.",
+  "atomTypes": [
+    { "id": "URL", "label": "URL", "description": "Web page URL pinned via IPFS as certified knowledge" },
+    { "id": "Person", "label": "User", "description": "Wallet address / on-chain identity" },
+    { "id": "DefinedTerm", "label": "Intention", "description": "Browsing intent classification (learning, work, fun, buying, inspiration, music)" },
+    { "id": "DefinedTerm", "label": "Theme", "description": "AI-extracted topic/category from browsing patterns" },
+    { "id": "DefinedTerm", "label": "Skill", "description": "User competency derived from browsing and AI analysis" },
+    { "id": "Thing", "label": "Certificate", "description": "On-chain browsing certification proving knowledge acquisition" },
+    { "id": "Thing", "label": "TrustCircle", "description": "Group of mutually trusted users forming a reputation cluster" }
+  ],
+  "predicates": [
+    { "id": "certifies", "label": "certifies", "description": "User certifies a URL as valuable knowledge", "subjectTypes": ["Person"], "objectTypes": ["URL"] },
+    { "id": "has_intention", "label": "has intention", "description": "URL is classified with a browsing intention", "subjectTypes": ["URL"], "objectTypes": ["DefinedTerm"] },
+    { "id": "has_theme", "label": "has theme", "description": "URL is tagged with an extracted topic", "subjectTypes": ["URL"], "objectTypes": ["DefinedTerm"] },
+    { "id": "trusts", "label": "trusts", "description": "User places trust in another user", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "distrusts", "label": "distrusts", "description": "User expresses distrust toward another user", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "has_skill", "label": "has skill", "description": "User has demonstrated competency in a skill area", "subjectTypes": ["Person"], "objectTypes": ["DefinedTerm"] },
+    { "id": "in_circle", "label": "in circle", "description": "User belongs to a trust circle", "subjectTypes": ["Person"], "objectTypes": ["Thing"] }
+  ]
+}

--- a/ontologies/spread-trust.json
+++ b/ontologies/spread-trust.json
@@ -1,0 +1,15 @@
+{
+  "app": "Spread Trust",
+  "repo": "intuition-box/spread-trust",
+  "description": "Burner wallet PWA for spreading $TRUST tokens on Intuition Chain. Enables easy onboarding and trust propagation.",
+  "atomTypes": [
+    { "id": "Person", "label": "User", "description": "Wallet address sending or receiving TRUST" },
+    { "id": "Thing", "label": "TrustTransfer", "description": "TRUST token transfer event on-chain" },
+    { "id": "EthereumAccount", "label": "BurnerWallet", "description": "Ephemeral wallet for frictionless onboarding" }
+  ],
+  "predicates": [
+    { "id": "trusts", "label": "trusts", "description": "User places trust in another user via token transfer", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "sent_trust", "label": "sent trust", "description": "User sent TRUST tokens to another", "subjectTypes": ["Person"], "objectTypes": ["Person"] },
+    { "id": "created_burner", "label": "created burner", "description": "User created an ephemeral burner wallet", "subjectTypes": ["Person"], "objectTypes": ["EthereumAccount"] }
+  ]
+}

--- a/ontologies/values.json
+++ b/ontologies/values.json
@@ -1,0 +1,17 @@
+{
+  "app": "Values",
+  "repo": "intuition-box/Values",
+  "description": "Blueprint for community organizations to define, endorse, and rank their core values on-chain.",
+  "atomTypes": [
+    { "id": "Organization", "label": "Organization", "description": "DAO or community entity defining its values" },
+    { "id": "DefinedTerm", "label": "Value", "description": "Core organizational value (e.g., transparency, decentralization)" },
+    { "id": "Person", "label": "Member", "description": "Organization member who endorses values" },
+    { "id": "Thing", "label": "Endorsement", "description": "Member's on-chain endorsement of a value" }
+  ],
+  "predicates": [
+    { "id": "upholds", "label": "upholds", "description": "Organization upholds a core value", "subjectTypes": ["Organization"], "objectTypes": ["DefinedTerm"] },
+    { "id": "endorses", "label": "endorses", "description": "Member endorses a specific value", "subjectTypes": ["Person"], "objectTypes": ["DefinedTerm"] },
+    { "id": "memberOf", "label": "member of", "description": "Person is a member of the organization", "subjectTypes": ["Person"], "objectTypes": ["Organization"] },
+    { "id": "proposes", "label": "proposes", "description": "Member proposes a new value for the organization", "subjectTypes": ["Person"], "objectTypes": ["DefinedTerm"] }
+  ]
+}


### PR DESCRIPTION
## Mission 04: Create Onchain Ontology for Intuition Ecosystem Apps

Closes #9

> Replaces #13 (closed — cleaned up unrelated commits from another branch)

### Summary

Formal ontology definitions for **11 out of 15** listed ecosystem apps, structured as JSON schemas defining atom types, predicates, and valid type combinations.

**This PR adds only data files** — zero code changes, zero risk to the existing app build.

### Files added (`ontologies/` directory)

| File | App | Atom Types | Predicates |
|------|-----|:----------:|:----------:|
| `sofia.json` | Sofia | 7 | 7 |
| `atlas.json` | Atlas | 5 | 5 |
| `agentid.json` | AgentId | 5 | 7 |
| `values.json` | Values | 4 | 4 |
| `graph.json` | Graph | 3 | 3 |
| `spread-trust.json` | Spread Trust | 3 | 3 |
| `fee-proxy.json` | Fee Proxy Template | 3 | 3 |
| `sofia-fee-proxy-dashboard.json` | Sofia Fee Proxy Dashboard | 3 | 3 |
| `rpc.json` | RPC | 3 | 2 |
| `mcp-server.json` | MCP Server | 3 | 3 |
| `ideation.json` | Intuition Ideation | 3 | 3 |
| `ontology.json` | Ontology | 3 | 3 |
| `_shared.json` | Cross-app shared types | 6 | 2 |
| `README.md` | Documentation | — | — |

### Repos not found (4 of 15)

`community-directory`, `l3-node`, `mcp-inspector`, `9atunments` — not present in the org.

### Cross-app shared types (`_shared.json`)

Ensures consistent atom IDs across all apps:
- `Person` — universal wallet identity (all 11 apps)
- `trusts` — universal trust predicate (Sofia, Graph, Spread Trust, AgentId)
- `Organization` — DAO/community entity (Atlas, Values)
- `DefinedTerm` — concepts, skills, tags (6 apps)

### Schema

All JSON files use a consistent structure compatible with the existing `PredicateRule` format from `src/data/predicates.ts`:

```typescript
interface AppOntology {
  app: string;
  repo: string;
  description: string;
  atomTypes: { id: string; label: string; description: string }[];
  predicates: { id: string; label: string; description: string; subjectTypes: string[]; objectTypes: string[] }[];
}
```
